### PR TITLE
Make hiredis build on all platforms again

### DIFF
--- a/net.c
+++ b/net.c
@@ -78,7 +78,11 @@ void __redisSetError(redisContext *c, int type, const char *str);
 
 static void redisContextCloseFd(redisContext *c) {
     if (c && c->fd >= 0) {
+#ifdef _WIN32
         closesocket(c->fd);
+#else
+        close(c->fd);
+#endif
         c->fd = -1;
     }
 }


### PR DESCRIPTION
This PR reworks some of the changes done to make hiredis build on Windows so that it continues to build on macOS and Linux. It boils down to two things:

- adding a missing ifdef
- reworking the Makefile so that Windows specific changes are only applied on Windows