### PR TITLE
Change macOS `install_name` link property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 ifeq ($(uname_S),Darwin)
   DYLIBSUFFIX=dylib
   DYLIB_MINOR_NAME=$(LIBNAME).$(HIREDIS_SONAME).$(DYLIBSUFFIX)
-  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
+  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,@executable_path/../Frameworks/$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
 endif
 ifeq ($(findstring MINGW, $(uname_S)), MINGW)
   DYLIBSUFFIX=dll


### PR DESCRIPTION
Define `install_name` to a value usable when the library is included in a macOS application bundle.