### PR TITLE
Use @rpath instead of @executable_path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 ifeq ($(uname_S),Darwin)
   DYLIBSUFFIX=dylib
   DYLIB_MINOR_NAME=$(LIBNAME).$(HIREDIS_SONAME).$(DYLIBSUFFIX)
-  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,@executable_path/../Frameworks/$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
+  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,@rpath/$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
 endif
 ifeq ($(findstring MINGW, $(uname_S)), MINGW)
   DYLIBSUFFIX=dll


### PR DESCRIPTION
This makes it easier to use the library outside of a Frameworks dir. One just needs to pass -rpath options to the linker.